### PR TITLE
Fix NextJS page disposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ This will create the following Docker containers:
 
     # If you DO NOT WANT to take advantage of hot reloading in NextJS:
     command: ./node_modules/.bin/next start
+
+    # If you want local changes to update in the Docker container, you can pass through project files like this:
+    # volumes:
+    #   - ./nextjs-with-apollo:/usr/src
+
     ```
 + `graphql-web` - A simple [React](https://reactjs.org) web application to work with our GraphQL API
     - By default, this project **WILL** hot reload changes made to this app in the Docker container. If you **DO NOT WANT** hot reloading, comment out the following lines in the `./docker-compose.yml` file:

--- a/README.md
+++ b/README.md
@@ -29,13 +29,16 @@ Once you have properly created and configured your `.env` files, you can spin up
 
 This will create the following Docker containers:
 + `graphql-nextjs` - A simple [NextJS](https://nextjs.org) web application to work with our GraphQL API
-    - By default, this project will hot reload changes made to this app in the Docker container. Simply comment out the following lines in the `./docker-compose.yml` file if you do not want that to occur:
+    - By default, this project **WILL** hot reload changes made to this app in the Docker container. If you DO NOT WANT hot reloading, make sure the following commands are updated for the `graphql-nextjs` service in the `./docker-compose.yml` file:
     ```sh
-    volumes:
-      - ./nextjs-with-apollo:/usr/src
+    # If you want to take advantage of hot reloading in NextJS:
+    # command: ./node_modules/.bin/next
+
+    # If you DO NOT WANT to take advantage of hot reloading in NextJS:
+    command: ./node_modules/.bin/next start
     ```
 + `graphql-web` - A simple [React](https://reactjs.org) web application to work with our GraphQL API
-    - By default, this project will hot reload changes made to this app in the Docker container. Simply comment out the following lines in the `./docker-compose.yml` file if you do not want that to occur:
+    - By default, this project **WILL** hot reload changes made to this app in the Docker container. If you DO NOT WANT hot reloading, comment out the following lines in the `./docker-compose.yml` file:
     ```sh
     volumes:
       - ./photo-share-client:/usr/src

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ Once you have properly created and configured your `.env` files, you can spin up
 
 This will create the following Docker containers:
 + `graphql-nextjs` - A simple [NextJS](https://nextjs.org) web application to work with our GraphQL API
-    - By default, this project **WILL** hot reload changes made to this app in the Docker container. If you DO NOT WANT hot reloading, make sure the following commands are updated for the `graphql-nextjs` service in the `./docker-compose.yml` file:
+    - By default, this project **WILL** hot reload changes made to this app in the Docker container. 
+        + There is an issue where hot module loading may prematurely dispose of NextJS pages and cause unexpected behavior **IN DEVELOPMENT MODE ONLY**. 
+        + If you **DO NOT WANT** hot reloading, make sure the following commands are updated for the `graphql-nextjs` service in the `./docker-compose.yml` file:
     ```sh
     # If you want to take advantage of hot reloading in NextJS:
     # command: ./node_modules/.bin/next
@@ -38,7 +40,7 @@ This will create the following Docker containers:
     command: ./node_modules/.bin/next start
     ```
 + `graphql-web` - A simple [React](https://reactjs.org) web application to work with our GraphQL API
-    - By default, this project **WILL** hot reload changes made to this app in the Docker container. If you DO NOT WANT hot reloading, comment out the following lines in the `./docker-compose.yml` file:
+    - By default, this project **WILL** hot reload changes made to this app in the Docker container. If you **DO NOT WANT** hot reloading, comment out the following lines in the `./docker-compose.yml` file:
     ```sh
     volumes:
       - ./photo-share-client:/usr/src

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,12 +6,15 @@ services:
       context: ./nextjs-with-apollo
       dockerfile: ./Dockerfile.dev
     container_name: 'graphql-nextjs'
+    # If you want to take advantage of hot reloading in NextJS:
     command: ./node_modules/.bin/next
+    # If you DO NOT WANT to take advantage of hot reloading in NextJS:
+    # command: ./node_modules/.bin/next start
     ports:
       - "3000:3000"
     # If you want local changes to update in the Docker container, you can pass through project files like this:
-    volumes:
-      - ./nextjs-with-apollo:/usr/src
+    # volumes:
+    #   - ./nextjs-with-apollo:/usr/src
     depends_on:
       - graphql-api
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,8 @@ services:
     ports:
       - "3000:3000"
     # If you want local changes to update in the Docker container, you can pass through project files like this:
-    # volumes:
-    #   - ./nextjs-with-apollo:/usr/src
+    volumes:
+      - ./nextjs-with-apollo:/usr/src
     depends_on:
       - graphql-api
 

--- a/nextjs-with-apollo/Dockerfile.dev
+++ b/nextjs-with-apollo/Dockerfile.dev
@@ -1,5 +1,4 @@
 FROM mhart/alpine-node:10
-
 # Add the bash shell
 RUN apk add --update bash && rm -rf /var/cache/apk/*
 
@@ -12,6 +11,9 @@ RUN npm install
 
 # Copy application code
 COPY . ./
+
+# Build our app
+RUN npm run build
 
 # Expose our application and node debugger ports
 EXPOSE 3000


### PR DESCRIPTION
This PR fixes an issue where the NextJS app - when run in development mode - may have pages disposed of automatically and make the app appear to be unresponsive.

To address this, the project has been updated so that the NextJS app may be started in production mode and not automatically hot reload modules.